### PR TITLE
Oilerbuilder enhanced, keywords fixed

### DIFF
--- a/Keywords.txt
+++ b/Keywords.txt
@@ -17,7 +17,7 @@ SetAlert	KEYWORD2
 SetMotorWorkPinMode	KEYWORD2
 SetMotorSensorDebounce	KEYWORD2
 SetStartEventToTargetActiveTime	KEYWORD2
-SetStartEventToTargetWork KEYWORD2
+SetStartEventToTargetWork	KEYWORD2
 SetStartEventToTime	KEYWORD2
 IsIdle	KEYWORD2				
 IsOff	KEYWORD2			


### PR DESCRIPTION
Oiler builder now
Allows Alerts to not use a pin (just a software state that can be queried with IsAlert() )
The default output sketch will try and locate the normal arduino location for sketches and add a new one called OilerBuilder
Will offer user to open windows explorer at the new sketch location after it is created
Wll not close automatically after creating sketch so user can make corrections and recreate sketch