### PR TITLE
State table improvements

### DIFF
--- a/Keywords.txt
+++ b/Keywords.txt
@@ -19,6 +19,7 @@ SetMotorSensorDebounce	KEYWORD2
 SetStartEventToTargetActiveTime	KEYWORD2
 SetStartEventToTargetWork	KEYWORD2
 SetStartEventToTime	KEYWORD2
+SetStopTarget	KEYWORD2
 IsIdle	KEYWORD2				
 IsOff	KEYWORD2			
 IsOiling	KEYWORD2	

--- a/examples/ComplexWithMonitoring/ComplexWithMonitoring.ino
+++ b/examples/ComplexWithMonitoring/ComplexWithMonitoring.ino
@@ -33,7 +33,7 @@
 #define	MACHINE_WORK_UNITS_TARGET		3			// Number of signals that indicates machine is ready (eg how many revolutions of spindle)
 
 #define ALERT_PIN						19			// digital Pin to signal if not completed oiling in multiple of oiler start target (eg elapsed time / revs / powered on time)
-#define ALERT_THRESHOLD					2			// Example only - set to twice normal target
+#define ALERT_THRESHOLD					(2 * ELAPSED_TIME_SECS ) // Example only - set to twice normal target
 
 #define ELAPSED_TIME_SECS				30			// Example only - restart paused pumps after 30 seconds
 #define POWERED_TIME_SECS				20			// Example only - restart paused pumps after 20 seconds of target machine having power
@@ -51,30 +51,19 @@ void setup ()
 		Error ( F ( "Unable to add stepper motor to oiler, stopped" ) );
 		while ( 1 );
 	}
-	// Add second motor on pin 8,9,10,11
-	if ( TheOiler.AddMotor ( 8, 9, 10, 11, STEPPER_SPEED_DEFAULT, OILED_DEVICE_ACTIVE_PIN2, PUMP2_NUM_DRIPS ) == false )
+	// Add second dc motor on pin 8
+	if ( TheOiler.AddMotor ( 8, OILED_DEVICE_ACTIVE_PIN2, PUMP2_NUM_DRIPS ) == false )
 	{
-		Error ( F ( "Unable to add stepper motor to oiler, stopped" ) );
+		Error ( F ( "Unable to add dc motor to oiler, stopped" ) );
 		while ( 1 );
 	}
 
-	/*
-	*		Alternatively if using relays to drive a dc motor replace the above with the code commented out below
-	*/
-	/*
-	// add 1 pin relay motor on Pin 4
-	if ( TheOiler.AddMotor ( 4, OILED_DEVICE_ACTIVE_PIN1, PUMP1_NUM_DRIPS ) == false )
+	// example of how to change pinmode of input pin used to monitor pump output (ie oil drips)
+	if ( TheOiler.SetMotorWorkPinMode ( 1, INPUT_PULLUP ) == false )
 	{
-		Error ( F ( "Unable to add relay motor to oiler, stopped" ) );
+		Error ( F ( "Unable set PinMode on dc motor, stopped" ) );
 		while ( 1 );
 	}
-	// add second 1 pin relay motor on Pin 5
-	if ( TheOiler.AddMotor ( 5, OILED_DEVICE_ACTIVE_PIN2, PUMP2_NUM_DRIPS ) == false )
-	{
-		Error ( F ( "Unable to add relay motor to oiler, stopped" ) );
-		while ( 1 );
-	}
-	*/
 
 	// This next step is optional, the Oiler will work without it. It simply gives a better experience.
 	// TheMachine represents the machine being oiled and uses two pins to signal when the machine is powered on (Active) and also when it has completed a 
@@ -92,11 +81,7 @@ void setup ()
 	TheOiler.AddMachine ( &TheMachine );
 
 	// Demonstrate how to turn on functionality that will generate a signal if oiling takes too long
-	if ( TheOiler.SetAlert ( ALERT_PIN, ALERT_THRESHOLD ) == false )
-	{
-		Error ( F ( "Unable to add Alert feature to oiler, stopped" ) );
-		while ( 1 );
-	}
+	TheOiler.SetAlert ( ALERT_PIN, ALERT_THRESHOLD );
 
 	// By default the oiler will work on an elapsed time basis
 
@@ -276,24 +261,24 @@ void DisplayStats ( void )
 		if ( uiWorkDone != uiLastCount [ i ] )
 		{
 			uiLastCount [ i ] = uiWorkDone;
-			ClearPartofLine ( STATS_ROW + i * 2 + 1, STATS_RESULT_COL, MAX_COLS - STATS_RESULT_COL );
-			AT ( STATS_ROW + i * 2 + 1, STATS_RESULT_COL, String ( uiWorkDone ) );
+			ClearPartofLine ( STATS_ROW + i * 3 + 1, STATS_RESULT_COL, MAX_COLS - STATS_RESULT_COL );
+			AT ( STATS_ROW + i * 3 + 1, STATS_RESULT_COL, String ( uiWorkDone ) );
 		}
 
 		bool bResult = TheOiler.IsMotorRunning ( i );
 		if ( bResult != bLastState [ i ] )
 		{
 			bLastState [ i ] = bResult;
-			ClearPartofLine ( STATS_ROW + i * 2 + 2, STATS_RESULT_COL, MAX_COLS - STATS_RESULT_COL );
-			AT ( STATS_ROW + i * 2 + 2, STATS_RESULT_COL, bResult == true ? F ( "Running" ) : F ( "Stopped" ) );
+			ClearPartofLine ( STATS_ROW + i * 3 + 2, STATS_RESULT_COL, MAX_COLS - STATS_RESULT_COL );
+			AT ( STATS_ROW + i * 3 + 2, STATS_RESULT_COL, bResult == true ? F ( "Running" ) : F ( "Stopped" ) );
 		}
 
 		uint32_t ulResult = TheOiler.GetTimeSinceMotorStarted ( i );
 		if ( ulResult != ulLastMotorRunTime [ i ] )
 		{
 			ulLastMotorRunTime [ i ] = ulResult;
-			ClearPartofLine ( STATS_ROW + i * 2 + 3, STATS_RESULT_COL, MAX_COLS - STATS_RESULT_COL );
-			AT ( STATS_ROW + i * 2 + 3, STATS_RESULT_COL, String ( ulResult ) );
+			ClearPartofLine ( STATS_ROW + i * 3 + 3, STATS_RESULT_COL, MAX_COLS - STATS_RESULT_COL );
+			AT ( STATS_ROW + i * 3 + 3, STATS_RESULT_COL, String ( ulResult ) );
 		}
 	}
 

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=OilerLib
-version=1.4.0
+version=1.5.0
 author=mark naylor
 maintainer=mark naylor
 sentence=OilerLib Library

--- a/src/FourPinStepperMotor.h
+++ b/src/FourPinStepperMotor.h
@@ -14,7 +14,7 @@
 #else
 #include "WProgram.h"
 #endif
-#include "Motor.h"
+#include "OilerMotor.h"
 #include "OilerLib.h"
 
 #define NUM_PINS        4
@@ -23,26 +23,28 @@
 #define STEPPER_MODE    HALF_STEPS
 #define NUM_PHASES      ( NUM_PINS * STEPPER_MODE )
 
-class FourPinStepperMotorClass : MotorClass
+class FourPinStepperMotorClass : public OilerMotorClass
 {
 public:
 
-    enum            eStatus { MOVING, STATIONARY, STOPPED };
-    FourPinStepperMotorClass ( uint8_t uiPin1, uint8_t uiPin2, uint8_t uiPin3, uint8_t uiPin4, uint32_t ulSpeed );
+    FourPinStepperMotorClass ( uint8_t uiPin1, uint8_t uiPin2, uint8_t uiPin3, uint8_t uiPin4, uint8_t uiWorkPin, uint32_t ulWorkThreshold, uint32_t ulDebouncems, uint32_t ulSpeed, uint16_t ulTimeThreshold );
     void            SetDirection ( eDirection Direction );
     void            NextStep ( void );
 
+    // Machine specific implmentation of base virtual pure functions
+    void			Idle ();
+    void			Start ();
+    void			PowerOff ();
+
     bool            On ( void );
     bool            Off ( void );
-    MotorClass::eState GetMotorState ( void );
 
 protected:
-    uint8_t         m_uiPins [ NUM_PINS ];  // Array of pins used to output signals to stepper driver
+                    uint8_t         m_uiPins [ NUM_PINS ];  // Array of pins used to output signals to stepper driver
     volatile        uint8_t         m_uiPhase;              // The current phase of stepper (in half mode we have 8 phases numbered 0 - 7)
-    uint32_t        m_ulStepInterval;       // the delay time between micros
-    uint32_t        m_ulLastStepTime;       // the last step time in micros
-    uint32_t        m_ulNextStepTime;       // time next step due in micros
-    eStatus         m_eState;               // keeps track of state of driver    
+                    uint32_t        m_ulStepInterval;       // the delay time between micros
+                    uint32_t        m_ulLastStepTime;       // the last step time in micros
+                    uint32_t        m_ulNextStepTime;       // time next step due in micros
 
     void            StepCW ( void );                        // Move motor 1 step in clockwise direction
     void            StepCCW ( void );                       // Move motor 1 step in conunter clock wise direction

--- a/src/Motor.cpp
+++ b/src/Motor.cpp
@@ -16,6 +16,7 @@ MotorClass::MotorClass ( uint32_t ulSpeed )
 	m_eDir = FORWARD;
 }
 
+
 bool MotorClass::On ( void )
 {
 	m_ulTimeStartedms = millis ();
@@ -73,4 +74,3 @@ void MotorClass::SetDirection ( eDirection eDir )
 }
 
 
-// MotorClass Motor;

--- a/src/Motor.h
+++ b/src/Motor.h
@@ -2,7 +2,7 @@
 //
 // (c) 2021 Mark Naylor
 //
-// defines base class for motors to drive oiler pump
+// defines base class for motors 
 //
 
 #ifndef _MOTOR_h
@@ -13,12 +13,23 @@
 #else
 #include "WProgram.h"
 #endif
+//#include "State.h"
+#define CALL_MEMBER_FN(object,ptrToMember)  ((object).*(ptrToMember))
 
 class MotorClass
 {
 public:
-	enum			eDirection { FORWARD, BACKWARD };
-	enum			eState { STOPPED = 1, RUNNING };
+	enum			eDirection
+	{
+		FORWARD, 
+		BACKWARD
+	};
+	enum			eState
+	{
+
+		STOPPED = 1, RUNNING
+	};
+
 	virtual bool	On ( void );						// Needs to be overriden to implement details of how motor is enabled
 	virtual bool	Off ( void );
 	uint32_t		GetTimeMotorStarted ( void );		// returns millis that it started
@@ -38,8 +49,6 @@ protected:
 	eState		m_eState;
 	eDirection	m_eDir;
 };
-
-//extern MotorClass Motor;
 
 #endif
 

--- a/src/OilerMotor.cpp
+++ b/src/OilerMotor.cpp
@@ -1,0 +1,182 @@
+#include "OilerMotor.h"
+// OilerMotor.cpp
+//
+// (c) 2021 Mark Naylor
+//
+// implements base class for motors driving an oiler, extends MotorClass and adds an output feature that tracks units of work (i.e. oil drips) from motor
+//
+#include "OilerMotor.h"
+
+OilerMotorClass::OilerMotorClass ( uint8_t uiWorkPin, uint32_t ulThreshold, uint32_t ulDebouncems, uint32_t ulSpeed, uint16_t uiTimeThreshold ) : MotorClass ( ulSpeed ), m_MotorState ( &MotorTable [ 0 ], ( sizeof ( MotorTable ) / sizeof ( MotorTable [ 0 ] ) ) )
+{
+	m_uiWorkPin = uiWorkPin;
+	m_ulLastWorkSignal = 0UL;
+	SetWorkThreshold ( ulThreshold );
+	SetDebouncems ( ulDebouncems );
+	SetTimeThreshold ( uiTimeThreshold );
+}
+
+bool OilerMotorClass::On ( void )
+{
+	ResetWorkUnits ();
+	return MotorClass::On ();
+}
+
+bool OilerMotorClass::Off ( void )
+{
+	return MotorClass::Off ();
+}
+
+void OilerMotorClass::IncWorkUnits ( uint16_t uiNewUnits )
+{
+	m_uiWorkCount += uiNewUnits;
+}
+
+void OilerMotorClass::ResetWorkUnits ( void )
+{
+	m_uiWorkCount = 0;
+}
+
+uint16_t OilerMotorClass::GetWorkUnits ()
+{
+	return m_uiWorkCount;
+}
+
+void OilerMotorClass::SetDebouncems ( uint32_t ulDebouncems )
+{
+	m_ulDebounceMin = ulDebouncems;
+}
+
+void OilerMotorClass::SetWorkThreshold ( uint32_t ulWorkThreshold )
+{
+	m_ulWorkThreshold = ulWorkThreshold;
+}
+
+void OilerMotorClass::SetTimeThreshold ( uint16_t uiTimeThresholdSec )
+{
+	m_uiTimeThresholdSec = uiTimeThresholdSec;
+}
+
+bool OilerMotorClass::Action ( eOilerMotorEvents eAction )
+{
+	return m_MotorState.ProcessEvent ( this, eAction );
+}
+
+
+/// <summary>
+/// Get the state table state of motor
+/// </summary>
+/// <returns>current state</returns>
+OilerMotorClass::eOilerMotorState OilerMotorClass::GetOilerMotorState ()
+{
+	return (eOilerMotorState)m_MotorState.GetCurrentState ();
+}
+
+/// <summary>
+/// Checks if motor is idle
+/// </summary>
+/// <returns>true if idle, else false</returns>
+bool OilerMotorClass::IsIdle ()
+{
+	return GetOilerMotorState () == IDLE ? true : false;
+}
+
+/// <summary>
+/// Checks if motor is moving
+/// </summary>
+/// <returns>true if moving, else false</returns>
+bool OilerMotorClass::IsMoving ()
+{
+	return GetOilerMotorState () == MOVING ? true : false;
+}
+
+/// <summary>
+/// Checks if motor is off
+/// </summary>
+/// <returns>true if off, else false</returns>
+bool OilerMotorClass::IsOff ()
+{
+	return GetOilerMotorState () == OFF ? true : false;
+}
+
+/// <summary>
+/// State table functon called to start motor moving
+/// </summary>
+/// <returns>new state</returns>
+uint16_t OilerMotorClass::TurnOn ()
+{
+	On ();				// Update status
+	Start ();			// physically start motor
+	return MOVING;		// new state
+}
+
+/// <summary>
+/// State table function called to turn off motor
+/// </summary>
+/// <returns>new state</returns>
+uint16_t OilerMotorClass::TurnOff ()
+{
+	Off ();				// Update status
+	PowerOff ();		// physically turn off
+	return OFF;			// new state
+}
+
+/// <summary>
+/// Checks if we have equalled or exceeded the threshold set for units of work (oil drips) and idles motor if true
+/// </summary>
+/// <returns>new state or existing state</returns>
+uint16_t OilerMotorClass::CheckWork ()
+{
+	uint16_t uiResult;
+
+	// check for spurious signal
+	if ( millis () - m_ulLastWorkSignal >= m_ulDebounceMin )
+	{
+		IncWorkUnits ( 1 );
+		if ( m_uiWorkCount >= m_ulWorkThreshold )
+		{
+			uiResult = IDLE;	// new state
+			Idle ();			// Physically idle motor
+			OilerMotorClass::Off ();				// update class, don't invoke
+		}
+		else
+		{
+			// not met threshold
+			uiResult = DoNothing ();
+		}
+	}
+	else
+	{
+		// ignore bad signal
+		uiResult = DoNothing ();
+	}
+	return uiResult;
+}
+
+/// <summary>
+/// Checks to see if the motor should restart after a set time has elapsed
+/// </summary>
+/// <returns></returns>
+uint16_t OilerMotorClass::CheckTime ()
+{
+	uint16_t uiResult;
+	if ( ( millis() - MotorClass::GetTimeMotorStopped () ) / 1000 >= m_uiTimeThresholdSec )
+	{
+		// time to start motor
+		uiResult = TurnOn ();
+	}
+	else
+	{
+		uiResult = DoNothing ();
+	}
+	return uiResult;
+}
+
+/// <summary>
+/// Keeps state of state machine unchanged
+/// </summary>
+/// <returns>existing state</returns>
+uint16_t OilerMotorClass::DoNothing ()
+{
+	return m_MotorState.GetCurrentState ();
+}

--- a/src/OilerMotor.h
+++ b/src/OilerMotor.h
@@ -1,0 +1,122 @@
+// OilerMotor.h
+//
+// (c) 2021 Mark Naylor
+//
+// defines class for motors driving an oiler, extends MotorClass and adds support for an input pin that signals when units of work (i.e. oil drips) are seen from from motor
+// functionally adds support to:
+//		only count work units that are separated by a specified debounce time (in milliseconds)
+//		idle the motor when a specified threshold of work units is met
+//		restart the motor after a specified time (in seconds) is passed
+//
+// This class implements a state table to control how the motor state changes in response to external events (e.g. signal work done, timer tick, on or off request
+//
+// Different types of motos used to do oiling e.g. a stepper motor or simple dc motor controlled by a relay switch derive from this class and override specific
+// functions to idle, stop and start the motor.
+//
+#ifndef _OILER_MOTOR_h
+#define _OILER_MOTOR_h
+
+#include "Motor.h"
+
+class OilerMotorClass : public MotorClass
+{
+protected:
+	class StateTable
+	{
+		typedef uint16_t ( OilerMotorClass::*OilerMotorStateCallback )( );
+	public:
+		typedef struct
+		{
+			uint16_t				uiCurrentState;				// Current state
+			uint16_t				uiEventId;					// Event that happened
+			OilerMotorStateCallback	FnState;					// function to be called to process this event when in this state
+		} STATE_TABLE_ENTRY, * PSTATE_TABLE_ENTRY;
+
+		StateTable ( PSTATE_TABLE_ENTRY pTable, uint16_t uiNumEntries );
+		uint16_t	GetCurrentState ( void );
+		bool		ProcessEvent ( OilerMotorClass* pMotor, uint16_t uiEventId );
+
+
+	protected:
+		PSTATE_TABLE_ENTRY	m_pTable;				// ptr to array of table entries
+		uint16_t			m_uiNumTableEntries;	// number of table entries
+		uint16_t			m_uiCurrentState;		// Current State
+
+		void		SetState ( uint16_t uiNewState );
+	};
+
+public:
+	// State table functions
+	virtual uint16_t		TurnOn ();							// function called to turn motor on and return new state
+	virtual uint16_t		TurnOff ();							// function called to turn motor off and return new state
+	virtual uint16_t		CheckWork ();						// function called to check if sufficient oil has been produced and to idle motor if it has
+	virtual uint16_t		CheckTime ();						// function called to check if time passed implies oiler not working
+	virtual uint16_t		DoNothing ();
+
+	// abstract function that derived classes must implement
+	virtual void			Idle () = 0;									// Idle motor, still energised but not moving
+	virtual void			Start () = 0;									// Start motor
+	virtual void			PowerOff () = 0;								// power off motor
+
+protected:
+	uint8_t		m_uiWorkPin;			// input Pin that indicates when a unit of work has been seen
+	uint32_t	m_ulWorkThreshold;		// number of units to be seen before idling motor
+	uint32_t	m_ulDebounceMin;		// number of milliseconds that must elapse before a subsequent workpin signal is treated as real
+	uint16_t	m_uiWorkCount;			// number of work units seen since last reset
+	uint32_t	m_ulLastWorkSignal;		// time of last signal in millis
+	uint16_t	m_uiTimeThresholdSec;	// time after which idle motor should restart
+	StateTable	m_MotorState;
+
+/*
+*	Oiler Motor State table
+*/
+
+public:
+	enum eOilerMotorState : uint16_t						// States motor can be in
+	{
+		OFF = 0,			// OFF => not energised, default state at start must be 0
+		IDLE,				// IDLE imples not moving but is being held stationary
+		MOVING
+	};
+
+	enum eOilerMotorEvents : uint16_t						// events that can change motor state
+	{
+		TURN_ON = 0,		// Request to turn on
+		TURN_OFF,			// Request to turn off
+		WORK_SEEN,			// Output seen
+		TIMER				// Timer check
+	};
+private:
+	StateTable::STATE_TABLE_ENTRY	MotorTable [ 12 ]
+	{
+		{ OFF,		TURN_ON,	&OilerMotorClass::TurnOn },				// start motor moving
+		{ OFF,		TURN_OFF,	&OilerMotorClass::DoNothing },			// if off no need to turn off, ignore
+		{ OFF,		WORK_SEEN,	&OilerMotorClass::DoNothing },			// if off and oil drips output, ignore
+		{ OFF,		TIMER,		&OilerMotorClass::DoNothing },			// if off ignore time
+		{ MOVING,	TURN_ON,	&OilerMotorClass::DoNothing },			// if moving no need to start moving, ignore
+		{ MOVING,	TURN_OFF,	&OilerMotorClass::TurnOff },			// if moving, turn off
+		{ MOVING,	WORK_SEEN,	&OilerMotorClass::CheckWork },			// if moving and oil drip see check if enough produced and idle motor
+		{ MOVING,	TIMER,		&OilerMotorClass::DoNothing },			// if moving, nothing to do
+		{ IDLE,		TURN_ON,	&OilerMotorClass::TurnOn },				// start motor moving
+		{ IDLE,		TURN_OFF,	&OilerMotorClass::TurnOff },			// turn off
+		{ IDLE,		WORK_SEEN,	&OilerMotorClass::DoNothing },			// oil produced whilst idle - ignore
+		{ IDLE,		TIMER,		&OilerMotorClass::CheckTime }			// see if we need to restart based on time idle
+	};
+
+public:
+	OilerMotorClass ( uint8_t uiWorkPin, uint32_t ulThreshold, uint32_t ulDebouncems, uint32_t ulSpeed, uint16_t ulTimeThreshold );
+	virtual bool On ( void );
+	virtual bool Off ( void );
+	void IncWorkUnits ( uint16_t uiNewUnits = 1 );
+	void ResetWorkUnits ( void );
+	void SetDebouncems ( uint32_t ulDebouncems );
+	void SetWorkThreshold ( uint32_t ulWorkThreshold );
+	void SetTimeThreshold ( uint16_t uiTimeThresholdSec );
+	bool Action ( eOilerMotorEvents eAction );
+	uint16_t GetWorkUnits ();
+	eOilerMotorState GetOilerMotorState ();
+	bool IsIdle ();
+	bool IsMoving ();
+	bool IsOff ();
+};
+#endif

--- a/src/RelayMotor.cpp
+++ b/src/RelayMotor.cpp
@@ -7,26 +7,40 @@
 
 #include "RelayMotor.h"
 
-RelayMotorClass::RelayMotorClass ( uint8_t uiPin ) : MotorClass ( 0 )
+RelayMotorClass::RelayMotorClass ( uint8_t uiRelayPin, uint8_t uiWorkPin, uint32_t ulWorkThreshold, uint32_t ulDebouncems, uint32_t ulTimeThreshold ) : OilerMotorClass ( uiWorkPin, ulWorkThreshold, ulDebouncems, 0, ulTimeThreshold )
 {
 	SetDirection ( FORWARD );
-	m_uiPin = uiPin;
-	pinMode ( m_uiPin, OUTPUT );
+	m_uiRelayPin = uiRelayPin;
+	pinMode ( m_uiRelayPin, OUTPUT );
 }
 
-bool RelayMotorClass::On ( void )
+/// <summary>
+/// Motor specific function to idle motor
+/// </summary>
+void RelayMotorClass::Idle ()
 {
-	digitalWrite ( m_uiPin, HIGH );
-	MotorClass::On ();
-	return true;
+	// Idle motor - for relay this means same as power off
+	PowerOff ();
 }
 
-bool RelayMotorClass::Off ( void )
+/// <summary>
+/// Motor specific function to Start motor
+/// </summary>
+void RelayMotorClass::Start ()
 {
-	digitalWrite ( m_uiPin, LOW );
-	MotorClass::Off ();
-	return true;
+	// Start motor - for relay this means switch on
+	digitalWrite ( m_uiRelayPin, HIGH );
 }
+
+/// <summary>
+/// Motor specific function to power off
+/// </summary>
+void RelayMotorClass::PowerOff ()
+{
+	// power off motor - for relay this means switch off
+	digitalWrite ( m_uiRelayPin, LOW );
+}
+
 
 void RelayMotorClass::SetDirection ( eDirection Direction )
 {
@@ -34,7 +48,3 @@ void RelayMotorClass::SetDirection ( eDirection Direction )
 	MotorClass::SetDirection ( Direction );
 }
 
-MotorClass::eState RelayMotorClass::GetMotorState ( void )
-{
-	return MotorClass::GetMotorState ();
-}

--- a/src/RelayMotor.h
+++ b/src/RelayMotor.h
@@ -13,19 +13,20 @@
 #else
 #include "WProgram.h"
 #endif
-#include "Motor.h"
+#include "OilerMotor.h"
 
-class RelayMotorClass : MotorClass
+class RelayMotorClass : public OilerMotorClass
 {
 public:
-	RelayMotorClass ( uint8_t uiPin );
-	bool				On ( void );
-	bool				Off ( void );
+						RelayMotorClass ( uint8_t uiPin, uint8_t uiWorkPin, uint32_t ulWorkThreshold, uint32_t ulDebouncems, uint32_t ulTimeThreshold );
+	void				Idle ();
+	void				Start ();
+	void				PowerOff ();
+
 	void				SetDirection ( eDirection Direction );		// Does nothing for this type of motor
-	MotorClass::eState	GetMotorState ( void );
 
 protected:
-	uint8_t		m_uiPin;
+	uint8_t		m_uiRelayPin;										// Pin that controls relay switch
 };
 
 #endif

--- a/src/State.cpp
+++ b/src/State.cpp
@@ -1,0 +1,67 @@
+//  State.h
+// 
+// (c) Mark Naylor July 2021
+//
+// State Table implementation
+//
+#include "OilerMotor.h"
+
+/// <summary>
+/// Initialise State table class with state table
+/// </summary>
+/// <param name="pTable">ptr to array of STATE_TABLE_ENTRIES</param>
+/// <param name="uiNumEntries">number of elements in array</param>
+OilerMotorClass::StateTable::StateTable ( PSTATE_TABLE_ENTRY pTable, uint16_t uiNumEntries )
+{
+	m_pTable = pTable;
+	m_uiNumTableEntries = uiNumEntries;
+	SetState ( 0 );
+}
+
+/// <summary>
+/// Returns current state
+/// </summary>
+/// <param name="">none</param>
+/// <returns>state</returns>
+uint16_t OilerMotorClass::StateTable::GetCurrentState ( void )
+{
+	return m_uiCurrentState;
+}
+
+/// <summary>
+/// Sets the current state
+/// </summary>
+/// <param name="uiNewState">new state id</param>
+void OilerMotorClass::StateTable::SetState ( uint16_t uiNewState )
+{
+	m_uiCurrentState = uiNewState;
+}
+
+/// <summary>
+/// Called to process a new event. If match not found, does nothing
+/// </summary>
+/// <param name="pMotor">reference to motor instance</param>
+/// <param name="uiEventId">Id of event to process</param>
+/// <returns>true if state changes, else false</returns>
+bool OilerMotorClass::StateTable::ProcessEvent ( OilerMotorClass* pMotor, uint16_t uiEventId )
+{
+	bool bResult = false;
+	for ( unsigned int i = 0; i < m_uiNumTableEntries; i++ )
+	{
+		if ( m_pTable [ i ].uiCurrentState == m_uiCurrentState )
+		{
+			if ( m_pTable [ i ].uiEventId == uiEventId )
+			{
+				OilerMotorStateCallback fn = m_pTable [ i ].FnState;
+				uint16_t t = CALL_MEMBER_FN ( *pMotor, fn )();
+				bResult = t == m_uiCurrentState ? false : true;
+				SetState ( t );
+				break;
+			}
+		}
+	}
+	return bResult;
+}
+
+
+

--- a/src/TargetMachine.cpp
+++ b/src/TargetMachine.cpp
@@ -143,7 +143,7 @@ bool TargetMachineClass::MachineUnitsDone ( void )
 }
 
 /// <summary>
-/// checks if the target machine has met or exceeded teh threshold set for time with power
+/// checks if the target machine has met or exceeded the threshold set for time with power
 /// </summary>
 /// <param name="">none</param>
 /// <returns>true if threshold met or exceeded, else false</returns>
@@ -181,6 +181,40 @@ TargetMachineClass::eMachineState TargetMachineClass::IsReady ( void )
 		m_timeActiveStarted = tNow;
 	}
 	return m_State;
+}
+
+/// <summary>
+/// Checks if TargetMachine has exceeded AlertThreshold in work units
+/// </summary>
+/// <param name="uiAlertThreshold">Value of alert threshold in seconds or units of work</param>
+/// <returns></returns>
+bool TargetMachineClass::IsWorkAlert ( uint16_t uiAlertThreshold )
+{
+	bool bResult = false;
+
+	if ( m_ulWorkUnitCount >= uiAlertThreshold )
+	{
+		bResult = true;
+	}
+
+	return bResult;
+}
+
+/// <summary>
+/// Checks if TargetMachine has exceeded AlertThreshold in work units
+/// </summary>
+/// <param name="uiAlertThreshold">Value of alert threshold in seconds or units of work</param>
+/// <returns></returns>
+bool TargetMachineClass::IsTimeAlert ( uint16_t uiAlertThreshold )
+{
+	bool bResult = false;
+
+	if ( m_timeActive >= uiAlertThreshold )
+	{
+		bResult = true;
+	}
+
+	return bResult;
 }
 
 /// <summary>

--- a/src/TargetMachine.h
+++ b/src/TargetMachine.h
@@ -55,6 +55,9 @@ public:
 	bool			SetWorkPinMode ( uint8_t uiMode );			// set Work input pin to INPUT or INPUT_PULLUP
 	bool			SetActiveState ( uint8_t uiState );			// set if HIGH or LOW indicates machine has power
 	void			CheckActivity ( void );						// check activity after change in signal from machine
+	bool			IsTimeAlert ( uint16_t uiAlertThreshold );	// check if exceeded alert threshold when in powered time mode
+	bool			IsWorkAlert ( uint16_t uiAlertThreshold );	// check if exceeded alert threshold when in work unit mode
+
 protected:
 	eMachineState	m_State;
 	eActiveState	m_Active;


### PR DESCRIPTION
Refactored to use state table to manage oiler motor states; 
changed alert to use a specified threshold value rather than a multiple
updated OilerBuilder to reflect alert change